### PR TITLE
Style corrections

### DIFF
--- a/arduino/AnalogInToESC/AnalogInToESC.ino
+++ b/arduino/AnalogInToESC/AnalogInToESC.ino
@@ -1,16 +1,16 @@
 /* Blue Robotics Example Code
 -------------------------------
- 
+
 Title: Analog Input to ESC Output (Arduino)
 
-Description: This code is an example of how to control the Blue Robotics 
-Thrusters and ESCs with an analog input signal. This can be useful to work 
+Description: This code is an example of how to control the Blue Robotics
+Thrusters and ESCs with an analog input signal. This can be useful to work
 with devices that output analog signals. The speed is controlled by a 0-5V
-analog input and the direction is controlled by a logical input with 0V for 
+analog input and the direction is controlled by a logical input with 0V for
 reverse and 5V for forward. The code is designed to operate two thrusters
 but can be extended to operate more.
 
-The code is designed for the Arduino Uno board and can be compiled and 
+The code is designed for the Arduino Uno board and can be compiled and
 uploaded via the Arduino 1.0+ software.
 
 -------------------------------
@@ -60,8 +60,8 @@ void setup() {
   Serial.begin(38400);
 
   // Set up direction pins as inputs
-  pinMode(DIRECTION_0,INPUT);
-  pinMode(DIRECTION_1,INPUT);
+  pinMode(DIRECTION_0, INPUT);
+  pinMode(DIRECTION_1, INPUT);
 
   // Set up Arduino pins to send servo signals to ESCs
   thruster0.attach(THRUSTER_0);
@@ -72,7 +72,7 @@ void setup() {
   thruster0.writeMicroseconds(CENTER_THROTTLE);
 
   // Delay to allow time for ESCs to initialize
-  delay(1000); 
+  delay(1000);
 }
 
 void loop() {
@@ -81,8 +81,8 @@ void loop() {
   int input1 = analogRead(ANALOG_IN_1)*(digitalRead(DIRECTION_1)*2-1);
 
   // Map analog input to a PWM output command given in microseconds
-  int output0 = map(input0,-1023,1023,CENTER_THROTTLE-MAX_FWD_REV_THROTTLE,CENTER_THROTTLE+MAX_FWD_REV_THROTTLE);
-  int output1 = map(input1,-1023,1023,CENTER_THROTTLE-MAX_FWD_REV_THROTTLE,CENTER_THROTTLE+MAX_FWD_REV_THROTTLE);
+  int output0 = map(input0, -1023, 1023, CENTER_THROTTLE-MAX_FWD_REV_THROTTLE, CENTER_THROTTLE+MAX_FWD_REV_THROTTLE);
+  int output1 = map(input1, -1023, 1023, CENTER_THROTTLE-MAX_FWD_REV_THROTTLE, CENTER_THROTTLE+MAX_FWD_REV_THROTTLE);
 
   // Output command to ESCs
   thruster0.writeMicroseconds(output0);

--- a/arduino/AnalogJoystickControl/AnalogJoystickControl.ino
+++ b/arduino/AnalogJoystickControl/AnalogJoystickControl.ino
@@ -1,15 +1,15 @@
 /* Blue Robotics Example Code
 -------------------------------
- 
+
 Title: Analog Joystick Control Example (Arduino)
 
-Description: This code is an example of how to use the Blue Robotics thrusters 
-and ESCs to control a simple underwater vehicle. The code is designed to use 
-analog joysticks (http://www.parallax.com/product/27808) and three thrusters. 
-The thrusters are oriented with two pointing forward, one on the left and one 
-on the right side of the vehicle, as well as a vertical thruster. 
+Description: This code is an example of how to use the Blue Robotics thrusters
+and ESCs to control a simple underwater vehicle. The code is designed to use
+analog joysticks (http://www.parallax.com/product/27808) and three thrusters.
+The thrusters are oriented with two pointing forward, one on the left and one
+on the right side of the vehicle, as well as a vertical thruster.
 
-The code is designed for the Arduino Uno board and can be compiled and 
+The code is designed for the Arduino Uno board and can be compiled and
 uploaded via the Arduino 1.0+ software.
 
 -------------------------------
@@ -83,7 +83,7 @@ void setup() {
   thrusterVertical.writeMicroseconds(CENTER_THROTTLE);
 
   // Delay to allow time for ESCs to initialize
-  delay(1000); 
+  delay(1000);
 }
 
 void loop() {

--- a/arduino/BareMinimum/BareMinimum.ino
+++ b/arduino/BareMinimum/BareMinimum.ino
@@ -1,12 +1,12 @@
 /* Blue Robotics Example Code
 -------------------------------
- 
+
 Title: Bare Minimum for ESC Control (Arduino)
 
-Description: This example code shows the bare minimum to get up and 
-running with the Blue Robotics Basic ESC and BlueESC using PWM signals. 
+Description: This example code shows the bare minimum to get up and
+running with the Blue Robotics Basic ESC and BlueESC using PWM signals.
 
-The code is designed for the Arduino Uno board and can be compiled and 
+The code is designed for the Arduino Uno board and can be compiled and
 uploaded via the Arduino 1.0+ software.
 
 -------------------------------


### PR DESCRIPTION
Correct code to use java style with 2 spaces indentation and some pad conventions.
This script can be used to correct future problems:
 - `astyle --unpad-paren --pad-header --indent=spaces=2 --style=java -xg -R "${PWD}/*.h" "${PWD}/*.cpp" "${PWD}/*.ino"`

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>